### PR TITLE
Trying to Fix lk21 source problem.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ google-auth-oauthlib
 gunicorn
 heroku3
 js2py
-lk21
+git+https://github.com/jusidama18/lk21
 lxml
 psutil
 psycopg2-binary


### PR DESCRIPTION
An admin, @Jusidama18 told that this is the solution to download Sbstream files and others which are getting error by the original repo of lk21, this fork may work. I request the devs to update this.